### PR TITLE
Update dependency versions

### DIFF
--- a/BTDatabase.cs
+++ b/BTDatabase.cs
@@ -1,8 +1,8 @@
 ﻿using System.IO;
 using System.Data;
+using Microsoft.Data.Sqlite;
 using TShockAPI;
 using TShockAPI.DB;
-using System.Data.SQLite;
 using MySql.Data.MySqlClient;
 using System.Collections.Generic;
 using Terraria;
@@ -35,7 +35,7 @@ namespace BindTools
 
 				case "sqlite":
 					string sql = Path.Combine(TShock.SavePath, "BindTools.sqlite");
-					db = new SQLiteConnection(string.Format("uri=file://{0},Version=3", sql));
+					db = new SqliteConnection($"Data Source={sql}");
 					break;
 			}
 

--- a/BindTools.csproj
+++ b/BindTools.csproj
@@ -6,14 +6,13 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
-    <PackageReference Include="MySql.Data" Version="9.3.0" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageReference Include="OTAPI.Upcoming" Version="3.3.10" />
+    <PackageReference Include="OTAPI.Upcoming" Version="3.3.11" />
     <PackageReference Include="System.Data.DataSetExtensions" Version="4.5.0" />
     <PackageReference Include="Microsoft.DotNet.UpgradeAssistant.Extensions.Default.Analyzers" Version="0.4.355802">
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="System.Data.Sqlite" Version="1.0.117" />
-    <PackageReference Include="TShock" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Data.Sqlite" Version="9.1.0" />
+    <PackageReference Include="TShock" Version="6.1.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
With the Microsoft.Data.Sqlite and MySql.Data dependencies, there were issues on plugin load with the version being different than what TShock uses.